### PR TITLE
Fix submodule url in gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "llm-answer-engine"]
+	path = llm-answer-engine
+	url = https://github.com/developersdigest/llm-answer-engine.git
+	branch = main


### PR DESCRIPTION
Add `llm-answer-engine` as a Git submodule to resolve build errors.

The build failed because the `llm-answer-engine` path was tracked as a submodule but the `.gitmodules` file was missing, preventing the build system from finding its URL. This change correctly configures the submodule.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa8f3edf-5ce1-4f63-84d4-764c48fc6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa8f3edf-5ce1-4f63-84d4-764c48fc6221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

